### PR TITLE
publish artifacts only from development branch builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,7 @@ stages:
             $(add-release-notes) > $(Build.ArtifactStagingDirectory)/ReleaseNotes.md
           displayName: Add release notes
         - task: GitHubRelease@0
-          condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+          condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/development'))
           displayName: "Update Github Release"
           inputs:
             gitHubConnection: github.com_AriaSalvatrice

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,6 +139,7 @@ stages:
             $(add-release-notes) > $(Build.ArtifactStagingDirectory)/ReleaseNotes.md
           displayName: Add release notes
         - task: GitHubRelease@0
+          condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
           displayName: "Update Github Release"
           inputs:
             gitHubConnection: github.com_AriaSalvatrice


### PR DESCRIPTION
Do not publish artifacts if CI build was not started on master branch.
See https://docs.microsoft.com/en-us/azure/devops/pipelines/build/ci-build-git

So it should be defined from what builds are artifacts published. eg. master or only release tags etc.
